### PR TITLE
Removed scss library plugin from required plugin

### DIFF
--- a/functions/plugin-manifest.php
+++ b/functions/plugin-manifest.php
@@ -26,12 +26,6 @@ function fuxt_register_required_plugins() {
 	);
 
 	$plugins = array(
-		array(
-			'name'    => 'SCSS-Library',
-			'slug'    => 'scss-library',
-			'version' => '0.4.1',
-			'required'     => true,
-		),
 		// array(
 		// 	'name'         => 'Advanced Custom Fields Pro',
 		// 	'slug'         => 'advanced-custom-fields-pro',


### PR DESCRIPTION
Compatibility with https://github.com/drewbaker/wp-easy/pull/25
We port over SCSS library feature into plugin.