### PR TITLE
Removed unnecessary param form use_layout() call

### DIFF
--- a/template.php
+++ b/template.php
@@ -4,7 +4,7 @@
 <head>
     <?php
     ob_start();
-    use_layout( get_query_var( 'layout', 'default' ) );
+    use_layout();
     $layout = ob_get_clean();
 
     // This is required by WordPress


### PR DESCRIPTION
We don't have paramenter for `use_layout()` function anymore. Removed it from template.php file